### PR TITLE
fix: hide empty nodes

### DIFF
--- a/packages/former/src/components/FormNode.vue
+++ b/packages/former/src/components/FormNode.vue
@@ -3,7 +3,7 @@
     v-if="isShown || mode === 'build'"
     :data-node="node._id"
     :draggable="mode === 'build'"
-    class="relative flex items-center duration-0 w-full rounded"
+    class="relative flex items-center duration-0 w-full rounded empty:hidden"
     :class="{
       'border-2 !border-blue-600': mode === 'build' && selectedNode?._id === node._id,
       'bg-zinc-300 dark:bg-zinc-700 rounded': mode === 'build' && !isShown,


### PR DESCRIPTION
We need to hide empty nodes because they can cause weird holes in the layout because flex box is adding gaps above and below of them